### PR TITLE
add initial modal bi-encoder app

### DIFF
--- a/applications/modal-bi-encoder/README.md
+++ b/applications/modal-bi-encoder/README.md
@@ -34,17 +34,17 @@ This application is capable or running locally as well as running on [Modal](htt
     uvicorn app:app --reload
     ```
 
-    The server will be running at `http://localhost:8000`.
+    The server will be running at <http://localhost:8000>.
 
-2. Run any of the following sample POST request commands
+2. Run any of the following sample POST request commands OR run the commands from the FastAPI docs <http://localhost:8000/docs>
 
-    **Encode:**
+    **Embeddings:**
 
     ```shell
-    curl -X POST -H "Content-Type: application/json" -d '{"texts": ["hello world", "hi there"]}' localhost:8000/encode
+    curl -X POST -H "Content-Type: application/json" -d '{"input": ["hello world", "hi there"]}' localhost:8000/embeddings
     ```
 
-    expected result: {"embeddings":[[0.034345343708992004,0.03316108137369156,0.021912500262260437, ... ]]}
+    expected result: {"object":"list","data":[{"object":"embedding","embedding":[0.034345392137765884,...,0.01511719822883606],"index":0}],"model":"BAAI/bge-large-en-v1.5","usage":{"prompt_tokens":0,"total_tokens":0}}
 
     **Cosine Similarity:**
 
@@ -72,13 +72,13 @@ This application is capable or running locally as well as running on [Modal](htt
 
 3. Run any of the following sample commands. Your <MODAL_APP_URL> can be found in your [Modal Running Apps](https://modal.com/apps)
 
-    **Encode:**
+    **Embeddings:**
 
     ```shell
-    curl -X POST -H "Content-Type: application/json" -d '{"texts": ["hello world", "hi there"]}' <MODAL_APP_URL>/encode
+    curl -X POST -H "Content-Type: application/json" -d '{"input": ["hello world", "hi there"]}' <MODAL_APP_URL>/embeddings
     ```
 
-    expected result: {"embeddings":[[0.034345343708992004,0.03316108137369156,0.021912500262260437, ... ]]}
+    expected result: {"object":"list","data":[{"object":"embedding","embedding":[0.034345392137765884,...,0.01511719822883606],"index":0}],"model":"BAAI/bge-large-en-v1.5","usage":{"prompt_tokens":0,"total_tokens":0}}
 
     **Cosine Similarity:**
 

--- a/applications/modal-bi-encoder/README.md
+++ b/applications/modal-bi-encoder/README.md
@@ -1,0 +1,91 @@
+# Modal Bi-Encoder Embedding Service
+
+This is an app to run a [bi-encoder](https://www.sbert.net/examples/applications/cross-encoder/README.html#bi-encoder-vs-cross-encoder) sentence transformer model to create text embeddings.
+
+This application is capable or running locally as well as running on [Modal](https://modal.com/). It also enables fine tuning the Bi-Encoder model both locally and on Modal.
+
+## Installation
+
+1. Clone the repository:
+
+    ```shell
+    git clone https://github.com//fastllm.git
+    ```
+
+2. Navigate to the project directory:
+
+    ```shell
+    cd applications/modal-bi-encoder
+    ```
+
+3. Install the required dependencies:
+
+    ```shell
+    pip install -r requirements.txt
+    ```
+
+## Usage
+
+### Local
+
+1. Start the FastAPI server:
+
+    ```shell
+    uvicorn app:app --reload
+    ```
+
+    The server will be running at `http://localhost:8000`.
+
+2. Run any of the following sample POST request commands
+
+    **Encode:**
+
+    ```shell
+    curl -X POST -H "Content-Type: application/json" -d '{"texts": ["hello world", "hi there"]}' localhost:8000/encode
+    ```
+
+    expected result: {"embeddings":[[0.034345343708992004,0.03316108137369156,0.021912500262260437, ... ]]}
+
+    **Cosine Similarity:**
+
+    ```shell
+    curl -X POST -H "Content-Type: application/json" -d '{"text1": "hello world", "text2": "hi earth"}' localhost:8000/cosine_similarity
+    ```
+
+    expected result: {"similarity":0.6782615184783936}
+
+    **TODO: finetune**
+
+### Modal
+
+1. Create a [Modal](https://modal.com/) account if you haven't already, and install the modal CLI
+
+    ```shell
+    pip install modal
+    ```
+
+2. Deploy the modal app
+
+    ```shell
+    modal serve modal_app.py
+    ```
+
+3. Run any of the following sample commands. Your <MODAL_APP_URL> can be found in your [Modal Running Apps](https://modal.com/apps)
+
+    **Encode:**
+
+    ```shell
+    curl -X POST -H "Content-Type: application/json" -d '{"texts": ["hello world", "hi there"]}' <MODAL_APP_URL>/encode
+    ```
+
+    expected result: {"embeddings":[[0.034345343708992004,0.03316108137369156,0.021912500262260437, ... ]]}
+
+    **Cosine Similarity:**
+
+    ```shell
+    curl -X POST -H "Content-Type: application/json" -d '{"text1": "hello world", "text2": "hi earth"}' <MODAL_APP_URL>/cosine_similarity 
+    ```
+
+    expected result: {"similarity":0.6782615184783936}
+
+    **TODO: finetune**

--- a/applications/modal-bi-encoder/app.py
+++ b/applications/modal-bi-encoder/app.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI
 from src.main import (
-    encode,
-    EncodeInput,
-    EncodeOutput,
+    embeddings,
+    EmbeddingInput,
+    EmbeddingOutput,
     cosine_similarity,
     CosineSimilarityInput,
     CosineSimilarityOutput,
@@ -13,9 +13,12 @@ app = FastAPI(
 )
 
 
-@app.post("/encode", response_model=EncodeOutput)
-def encode_request(input: EncodeInput):
-    return encode(input)
+@app.post("/embeddings", response_model=EmbeddingOutput)
+def embeddings_request(req: EmbeddingInput):
+    """Create embedding vector(s) from input text(s).
+    Modeled after OpenAI Create Embeddings endpoint <https://platform.openai.com/docs/api-reference/embeddings/create>
+    """
+    return embeddings(req)
 
 
 @app.post("/cosine_similarity", response_model=CosineSimilarityOutput)

--- a/applications/modal-bi-encoder/app.py
+++ b/applications/modal-bi-encoder/app.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI
+from src.main import (
+    encode,
+    EncodeInput,
+    EncodeOutput,
+    cosine_similarity,
+    CosineSimilarityInput,
+    CosineSimilarityOutput,
+)
+
+app = FastAPI(
+    title="Sentence Transformer: Bi-Encoder",
+)
+
+
+@app.post("/encode", response_model=EncodeOutput)
+def encode_request(input: EncodeInput):
+    return encode(input)
+
+
+@app.post("/cosine_similarity", response_model=CosineSimilarityOutput)
+def cosine_similarity_request(input: CosineSimilarityInput):
+    return cosine_similarity(input)

--- a/applications/modal-bi-encoder/modal_app.py
+++ b/applications/modal-bi-encoder/modal_app.py
@@ -1,0 +1,26 @@
+import modal
+from src.main import get_model
+from app import app
+
+stub = modal.Stub("bi-encoder")
+
+
+def download_model():
+    return get_model()
+
+
+image = (
+    modal.Image.debian_slim()
+    .pip_install(
+        "fastapi",
+        "sentence-transformers",
+        "pydantic",
+    )
+    .run_function(download_model)
+)
+
+
+@stub.function(image=image)
+@modal.asgi_app()
+def fastapi_app():
+    return app

--- a/applications/modal-bi-encoder/requirements.txt
+++ b/applications/modal-bi-encoder/requirements.txt
@@ -1,0 +1,4 @@
+modal
+fastapi
+pydantic
+sentence-transformers

--- a/applications/modal-bi-encoder/src/main.py
+++ b/applications/modal-bi-encoder/src/main.py
@@ -1,0 +1,53 @@
+from sentence_transformers import SentenceTransformer, util
+from functools import lru_cache
+from pydantic import BaseModel
+from typing import List
+
+MODEL_NAME = "BAAI/bge-large-en-v1.5"
+
+# Pydantic types
+
+
+class EncodeInput(BaseModel):
+    texts: List[str]
+
+
+class EncodeOutput(BaseModel):
+    embeddings: List[List[float]]
+
+
+class CosineSimilarityInput(BaseModel):
+    text1: str
+    text2: str
+
+
+class CosineSimilarityOutput(BaseModel):
+    similarity: float
+
+
+# Functions
+
+
+@lru_cache(maxsize=1)
+def get_model(model_name=MODEL_NAME) -> SentenceTransformer:
+    return SentenceTransformer(model_name)
+
+
+def encode(input: EncodeInput) -> EncodeOutput:
+    """Encode a List[str] using the given sentence embedding model
+    Source: https://www.sbert.net/docs/quickstart.html"""
+    model = get_model()
+    embeddings = model.encode(input.texts, convert_to_tensor=True)
+    # Conver tensor to a List[float] for pydantic output
+    return EncodeOutput(embeddings=embeddings.tolist())
+
+
+def cosine_similarity(input: CosineSimilarityInput) -> CosineSimilarityOutput:
+    """Calculate cosine similarity of 2 embedded strings using the given sentence embedding model
+    Source: https://www.sbert.net/docs/quickstart.html"""
+    model = get_model()
+    emb1 = model.encode(input.text1)
+    emb2 = model.encode(input.text2)
+    cos_sim = util.cos_sim(emb1, emb2)
+    # Convert tensor to float for pydantic output
+    return CosineSimilarityOutput(similarity=cos_sim.tolist()[0][0])

--- a/applications/modal-bi-encoder/src/main.py
+++ b/applications/modal-bi-encoder/src/main.py
@@ -1,19 +1,38 @@
 from sentence_transformers import SentenceTransformer, util
 from functools import lru_cache
-from pydantic import BaseModel
-from typing import List
+from pydantic import BaseModel, Field
+from typing import List, Union
 
 MODEL_NAME = "BAAI/bge-large-en-v1.5"
 
+
 # Pydantic types
+class EmbeddingInput(BaseModel):
+    # modeled after request body from https://platform.openai.com/docs/api-reference/embeddings/create
+    input: Union[str, List[str]] = Field(..., description="The input text(s) to embed")
+    model: str = MODEL_NAME
 
 
-class EncodeInput(BaseModel):
-    texts: List[str]
+class Embedding(BaseModel):
+    # modeled after https://platform.openai.com/docs/api-reference/embeddings/object
+    object: str = "embedding"
+    embedding: List[float]
+    index: int = 0
 
 
-class EncodeOutput(BaseModel):
-    embeddings: List[List[float]]
+class Usage(BaseModel):
+    # modeled after usage object from https://platform.openai.com/docs/api-reference/embeddings/create
+    # TODO: implement token tracking
+    prompt_tokens: int = 0
+    total_tokens: int = 0
+
+
+class EmbeddingOutput(BaseModel):
+    # modeled after response from https://platform.openai.com/docs/api-reference/embeddings/create
+    object: str = "list"
+    data: List[Embedding]
+    model: str
+    usage: Usage = Field(..., default_factory=Usage)
 
 
 class CosineSimilarityInput(BaseModel):
@@ -33,13 +52,16 @@ def get_model(model_name=MODEL_NAME) -> SentenceTransformer:
     return SentenceTransformer(model_name)
 
 
-def encode(input: EncodeInput) -> EncodeOutput:
-    """Encode a List[str] using the given sentence embedding model
+def embeddings(req: EmbeddingInput) -> EmbeddingOutput:
+    """Embed texts using the given sentence embedding model
     Source: https://www.sbert.net/docs/quickstart.html"""
-    model = get_model()
-    embeddings = model.encode(input.texts, convert_to_tensor=True)
-    # Conver tensor to a List[float] for pydantic output
-    return EncodeOutput(embeddings=embeddings.tolist())
+    model = get_model(req.model)
+    sentences = req.input if isinstance(req.input, List) else [req.input]
+    embeddings = model.encode(sentences, convert_to_tensor=True)
+    return EmbeddingOutput(
+        data=[Embedding(embedding=e, index=i) for i, e in enumerate(embeddings)],
+        model=req.model,
+    )
 
 
 def cosine_similarity(input: CosineSimilarityInput) -> CosineSimilarityOutput:


### PR DESCRIPTION
# Add initial modal bi-encoder app

## Features

FastAPI app
* deployable on Modal
* endpoints include `/encode` and `/cosine_similarity`
* will include `finetune` endpoint in next PR

README
* Summary
* Installation instructions
* Usage instructions and example calls for both local/modal deployment

## Future features

Finetune endpoint
* finetune the sentence transformer model given input data
Will be based on code here: https://www.sbert.net/docs/training/overview.html#loss-functions
```python
from sentence_transformers import SentenceTransformer, InputExample, losses
from torch.utils.data import DataLoader

#Define the model. Either from scratch of by loading a pre-trained model
model = SentenceTransformer('distilbert-base-nli-mean-tokens')

#Define your train examples. You need more than just two examples...
train_examples = [InputExample(texts=['My first sentence', 'My second sentence'], label=0.8),
    InputExample(texts=['Another pair', 'Unrelated sentence'], label=0.3)]

#Define your train dataset, the dataloader and the train loss
train_dataloader = DataLoader(train_examples, shuffle=True, batch_size=16)
train_loss = losses.CosineSimilarityLoss(model)

#Tune the model
model.fit(train_objectives=[(train_dataloader, train_loss)], epochs=1, warmup_steps=100)
``` 
* will create a new `src/datasets.py` file to handle importing data
* modify existing `/encode` and `/cosine_similarity` endpoints to be able to use the new finetuned model
* figure out how to make the finetuned model downloadable locally and on modal