### PR TITLE
Adding Wandb Logging to the wikipedia batching

### DIFF
--- a/applications/wikipedia/requirements.txt
+++ b/applications/wikipedia/requirements.txt
@@ -1,3 +1,3 @@
-datasets
 modal
-httpx
+datasets
+wandb


### PR DESCRIPTION
Opening up an initial PR first 

Current blockers/things I'm thinking about

1. GPU Visualisation : Currently, what we do is to run multiple batch sizes ( to pass to the server ) and then log the results. This doesn't allow me to group the GPU utilization results for containers based on parameters such as batch size ( for server ) , input batch size or N_gpu

2. Logging of final results - Are there better results that I can track?