### PR TITLE
Use larger batches for embedding example

### DIFF
--- a/applications/wikipedia/download.py
+++ b/applications/wikipedia/download.py
@@ -26,7 +26,7 @@ def list_all_files():
 
 # Set a really high timeout
 @stub.function(volumes={cache_dir: volume}, timeout=3000)
-def download_dataset(cache=False):
+def download_dataset(cache=True):
     # Redownload the dataset
     from datasets import load_dataset
     import time


### PR DESCRIPTION
Sending larger batches to each Modal function instead of relying on `allow_concurrent_inputs`. A bit annoying to do this, but this allows us to embed 10% of wikipedia in 5 minutes, using 30-50 GPUs:

![image](https://github.com/567-labs/fastllm/assets/5786378/1f58461a-7d02-4e2d-a93d-89a1d24f36d8)
