### PR TITLE
Adding a fix to solve the np bug

### DIFF
--- a/applications/wikipedia/main.py
+++ b/applications/wikipedia/main.py
@@ -138,7 +138,7 @@ class TextEmbeddingsInference:
             for chunk_batch in generate_batches(chunks, batch_size=BATCH_SIZE)
         ]
 
-        embeddings = np.concatenate(await asyncio.gather(*coros))
+        embeddings = np.vstack(await asyncio.gather(*coros))
         return chunks, embeddings
 
 
@@ -279,7 +279,7 @@ def embed_dataset(down_scale: float = 0.005, batch_size: int = 512 * 50):
 
 @stub.local_entrypoint()
 def main():
-    scale = 0.001
+    scale = 0.01
     batch_size = 512 * 150
     with open("benchmarks.json", "a") as f:
         benchmark = embed_dataset.remote(down_scale=scale, batch_size=batch_size)


### PR DESCRIPTION
> EDIT: still getting the same bug once I scaled up to much larger size.

 ```
  Exception: all the input array dimensions except for the concatenation axis must match exactly, but along dimension 1, the array at index 0 has size 384 and the array at index 49 has size 1
  Exception: all the input array dimensions except for the concatenation axis must match exactly, but along dimension 1, the array at index 0 has size 384 and the array at index 32 has size 1
  Exception: all the input array dimensions except for the concatenation axis must match exactly, but along dimension 1, the array at index 0 has size 384 and the array at index 21 has size 1
  Generated a total of 51833439 embeddings
  ```

----

Adding a big which fixes an issue with using np.concetenate by migrating over to use np.vstack instead. 

Quick Sanity Check

```
import numpy as np

x = [[1, 2, 3], [4, 5, 6]]

y = [[3, 4, 6]]

z = [[2, 4, 5]]

arrs = np.vstack([np.array(arr) for arr in [x, y, z]])

expected = np.array([[1, 2, 3], [4, 5, 6], [3, 4, 6], [2, 4, 5]])
assert np.array_equal(arrs, expected)
```

This allows me to run the scripts without getting the same error as before and should allow for a much better experience